### PR TITLE
Change `white-space: pre` to `pre-wrap`

### DIFF
--- a/src/styles/editor.scss
+++ b/src/styles/editor.scss
@@ -25,7 +25,7 @@
   }
 
   .preWhiteSpace {
-    white-space: pre;
+    white-space: pre-wrap;
   }
 
   .caret {


### PR DESCRIPTION
It will [work the same but break lines on whitespace](https://developer.mozilla.org/en-US/docs/Web/CSS/white-space#values) as to not overflow the input and cause the need for horizontal scrolling. 

with `white-space: pre`:

<img width="599" alt="Screen Shot 2021-08-12 at 7 57 44 pm" src="https://user-images.githubusercontent.com/62878664/129192834-4728b444-5c6a-458b-b48c-be3703cd05cd.png">

with `white-space: pre-wrap`:

<img width="599" alt="Screen Shot 2021-08-12 at 7 59 38 pm" src="https://user-images.githubusercontent.com/62878664/129193053-0f457311-c3cc-41a3-8ab4-a306c2de09c2.png">