### PR TITLE
Add `PropTypes.object` to `errorMessage`

### DIFF
--- a/src/components/Terminal.tsx
+++ b/src/components/Terminal.tsx
@@ -69,7 +69,7 @@ Terminal.propTypes = {
     PropTypes.node
   ])),
   welcomeMessage: PropTypes.oneOfType([PropTypes.string, PropTypes.func, PropTypes.node]),
-  errorMessage: PropTypes.string
+  errorMessage: PropTypes.oneOfType([PropTypes.string, PropTypes.object])
 };
 
 Terminal.defaultProps = {


### PR DESCRIPTION
I dont think this will affect anything negatively, everything seems to be working fine, but it will allow styling of error messages like:

`errorMessage={<span style={{ color: 'red' }}>Unknown command</span>}`

without a `PropTypes` error like in [#36](https://github.com/bony2023/react-terminal/issues/36#issue-968194683)