### PR TITLE
fix: mobile input not working

### DIFF
--- a/package.json
+++ b/package.json
@@ -102,6 +102,6 @@
   },
   "dependencies": {
     "prop-types": "^15.7.2",
-    "react-device-detect": "^2.2.2"
+    "react-device-detect": "2.1.2"
   }
 }

--- a/src/components/Editor.tsx
+++ b/src/components/Editor.tsx
@@ -33,9 +33,10 @@ export default function Editor(props: any) {
     consoleFocused,
     prompt,
     commands,
-    errorMessage, 
+    errorMessage,
     enableInput,
-    defaultHandler
+    defaultHandler,
+    wrapperRef
   );
 
   return (

--- a/src/hooks/editor.tsx
+++ b/src/hooks/editor.tsx
@@ -206,7 +206,8 @@ export const useCurrentLine = (
   commands: any,
   errorMessage: any,
   enableInput: boolean,
-  defaultHandler: any
+  defaultHandler: any,
+  wrapperRef: any
 ) => {
   const style = React.useContext(StyleContext);
   const themeStyles = React.useContext(ThemeContext);
@@ -223,10 +224,6 @@ export const useCurrentLine = (
       if (!isMobile) {
         return;
       }
-
-      if (consoleFocused) {
-        mobileInputRef.current.focus();
-      }
     },
     [consoleFocused]
   );
@@ -240,6 +237,14 @@ export const useCurrentLine = (
     },
     [processCurrentLine]
   );
+
+  React.useEffect(() => {
+    if(wrapperRef !== null) {
+      wrapperRef.current.onclick = () => {
+        mobileInputRef.current.focus();
+      }
+    }
+  },[])
 
   const mobileInput = isMobile && enableInput? (
     <div className={style.mobileInput}>

--- a/yarn.lock
+++ b/yarn.lock
@@ -6317,12 +6317,12 @@ rc@^1.0.1, rc@^1.1.6:
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
 
-react-device-detect@^2.2.2:
-  version "2.2.2"
-  resolved "https://registry.yarnpkg.com/react-device-detect/-/react-device-detect-2.2.2.tgz#dbabbce798ec359c83f574c3edb24cf1cca641a5"
-  integrity sha512-zSN1gIAztUekp5qUT/ybHwQ9fmOqVT1psxpSlTn1pe0CO+fnJHKRLOWWac5nKxOxvOpD/w84hk1I+EydrJp7SA==
+react-device-detect@2.1.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/react-device-detect/-/react-device-detect-2.1.2.tgz#60abb6fa361ec4cc839469a0c4c3e9b8ea17d6b5"
+  integrity sha512-N42xttwez3ECgu4KpOL2ICesdfoz8NCBfmc1rH9FRYSjH7NmMyANPSrQ3EvAtJyj/6TzJNhrANSO38iXjCB2Ug==
   dependencies:
-    ua-parser-js "^1.0.2"
+    ua-parser-js "^0.7.30"
 
 react-is@^16.12.0, react-is@^16.13.1, react-is@^16.8.6:
   version "16.13.1"
@@ -7518,10 +7518,10 @@ typescript@^4.3.5:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.8.3.tgz#d59344522c4bc464a65a730ac695007fdb66dd88"
   integrity sha512-goMHfm00nWPa8UvR/CPSvykqf6dVV8x/dp0c5mFTMTIu0u0FlGWRioyy7Nn0PGAdHxpJZnuO/ut+PpQ8UiHAig==
 
-ua-parser-js@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-1.0.2.tgz#e2976c34dbfb30b15d2c300b2a53eac87c57a775"
-  integrity sha512-00y/AXhx0/SsnI51fTc0rLRmafiGOM4/O+ny10Ps7f+j/b8p/ZY11ytMgznXkOVo4GQ+KwQG5UQLkLGirsACRg==
+ua-parser-js@^0.7.30:
+  version "0.7.32"
+  resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.32.tgz#cd8c639cdca949e30fa68c44b7813ef13e36d211"
+  integrity sha512-f9BESNVhzlhEFf2CHMSj40NWOjYPl1YKYbrvIr/hFTDEmLq7SRbWvm7FcdcpCYT95zrOhC7gZSxjdnnTpBcwVw==
 
 uid-number@0.0.6:
   version "0.0.6"


### PR DESCRIPTION
Fixes: https://github.com/bony2023/react-terminal/issues/234

"Fixes" however there are some downsides to this. Because browsers require an event to be fired to control anything we can no longer set "consoleFocused" to true to allow a virtual keyboard to show. I think this is just a limitation of devices?

Second, I overwrite the parent wrapper's onClick event which isn't being used currently but if it is modified in the future we will have to change this logic.

I also downgraded react-device-detect to 2.1.2 from 2.2.2 as from testing isMobile was always wrong on an actual mobile device even though it was correct on a browsers mobile simulation.