### PR TITLE
Issue 270:- Output of the defaultHandler not preserving new line characters.

### DIFF
--- a/src/hooks/editor.tsx
+++ b/src/hooks/editor.tsx
@@ -180,7 +180,7 @@ export const useBufferedContent = (
             <span style={{ color: themeStyles.themePromptColor }}>{prompt}</span>
             <span className={`${style.lineText} ${style.preWhiteSpace}`}>{currentText}</span>
             {output ? (
-              <span>
+              <span className={`${style.lineText} ${style.preWhiteSpace}`}>
                 <br />
                 {output}
               </span>


### PR DESCRIPTION
Adding pre-wrap style to the output from
defaulthandler to preserve new line characters
PR for issue - Output of the defaultHandler not preserving new line characters. (https://github.com/bony2023/react-terminal/issues/270)