### PR TITLE
feat: add sendCommand, improve typing

### DIFF
--- a/src/components/Editor.tsx
+++ b/src/components/Editor.tsx
@@ -8,7 +8,11 @@ import {
   useScrollToBottom,
 } from "../hooks/editor";
 
-export default function Editor(props: any) {
+export interface EditorHandle {
+  sendCommand: (command: string) => void;
+}
+
+const Editor = React.forwardRef<EditorHandle, any>((props, ref) => {
   const wrapperRef = React.useRef(null);
   const style = React.useContext(StyleContext);
   const themeStyles = React.useContext(ThemeContext);
@@ -28,7 +32,7 @@ export default function Editor(props: any) {
     defaultHandler
   } = props;
 
-  const currentLine = useCurrentLine(
+  const { currentLine, setEditorInput, setProcessCurrentLine } = useCurrentLine(
     caret,
     consoleFocused,
     prompt,
@@ -39,6 +43,13 @@ export default function Editor(props: any) {
     wrapperRef
   );
 
+  React.useImperativeHandle(ref, () => ({
+    sendCommand: (cmd: string) => {
+      setEditorInput(cmd);
+      setProcessCurrentLine(true);
+    }
+  }));
+
   return (
     <div id={"terminalEditor"} ref={wrapperRef} className={`${style.editor} ${!showControlBar ? style.curvedTop : null} ${showControlBar ? style.editorWithTopBar : null}`} style={{ background: themeStyles.themeBGColor }}>
       {welcomeMessage}
@@ -46,4 +57,6 @@ export default function Editor(props: any) {
       {currentLine}
     </div>
   );
-}
+});
+
+export default Editor;

--- a/src/hooks/editor.tsx
+++ b/src/hooks/editor.tsx
@@ -325,7 +325,11 @@ export const useCurrentLine = (
     defaultHandler
   );
 
-  return currentLine;
+  return {
+    currentLine,
+    setEditorInput,
+    setProcessCurrentLine,
+  };
 };
 
 export const useScrollToBottom = (changesToWatch: any, wrapperRef: any) => {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,18 +1,28 @@
 import * as React from "react";
 import * as Terminal from "./components/Terminal";
 import * as ContextProvider from "./contexts";
-import { 
+import {
   TerminalContextProvider as _TerminalContextProvider,
   TerminalContext as _TerminalContext
 } from "./contexts/TerminalContext";
 
-export function ReactTerminal(props: any): any {
+export type ReactTerminalHandle = Terminal.TerminalHandle;
+
+export const ReactTerminal = React.forwardRef<ReactTerminalHandle, Partial<Terminal.TerminalProps>>(
+  (props: Terminal.TerminalProps, ref) => {
+  const terminalRef = React.useRef(undefined);
+
+  React.useImperativeHandle(ref, () => ({
+    sendCommand: terminalRef.current?.sendCommand
+  }));
+
   return (
     <ContextProvider.default>
-      <Terminal.default {...props} />
+      <Terminal.default {...props} ref={terminalRef} />
     </ContextProvider.default>
   );
 }
+);
 
 export const TerminalContextProvider = _TerminalContextProvider;
 export const TerminalContext = _TerminalContext;


### PR DESCRIPTION
Hello,

This PR introduces a "sendCommand" method to invoke commands programmatically, here is a sample usage :

```typescript
import { useEffect, useRef } from "react";
import { ReactTerminal, type ReactTerminalHandle } from "react-terminal";

const commands = {
  cd: (directory: string) => `changed path to ${directory}`
};

function App() {
  const termRef = useRef<ReactTerminalHandle>(null)

  useEffect(() => {
    setTimeout(() => {
      termRef.current?.sendCommand("cd foo")
    }, 3000)
  }, [])

  return (
    <ReactTerminal
      commands={commands}
      welcomeMessage="hello world"
      ref={termRef}
    />
  );
}

export default App;
```

I also noticed that the typing was not correctly exported on `ReactTerminal` component, this PR should also fix this issue.